### PR TITLE
docs: add instructions for GENERATE_DOC and update README/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to PAELLADOC will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-15
+## [0.2.0] - 2025-04-05
 
 ### Added
 - **Dynamic Template-Based Menu System**: Replaced fixed menu with a dynamic menu generated from existing templates
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solved inconsistency between menu and available templates
 - Improved documentation file saving process
 
-## [0.1.0] - 2025-04-04
+## [0.1.0] - 2024-04-04
 
 ### Breaking Changes
 - Implementation of repository documentation generation system (GENERATE_DOC)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🥘 PAELLADOC: The development exoskeleton
 
-![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)
 ![Status](https://img.shields.io/badge/status-active-success.svg)
 ![Cursor](https://img.shields.io/badge/cursor-0.47+-green.svg)
 ![Compatibility](https://img.shields.io/badge/compatibility-cursor%200.47+-orange.svg)
-![Updated](https://img.shields.io/badge/updated-2025--04--04-brightgreen.svg)
+![Updated](https://img.shields.io/badge/updated-2025--04--05-brightgreen.svg)
 [![GitHub Stars](https://img.shields.io/github/stars/jlcases/paelladoc?style=social)](https://github.com/jlcases/paelladoc)
 [![GitHub Forks](https://img.shields.io/github/forks/jlcases/paelladoc?style=social)](https://github.com/jlcases/paelladoc/fork)
 [![X Community](https://img.shields.io/badge/X%20Community-PAellaDOC-blue)](https://x.com/i/communities/1907494161458090406)
@@ -159,8 +159,10 @@ Like a well-trained chef, PAELLADOC will:
 9. **Repository Analysis and Documentation**
    - Extract repository context with GENERATE_CONTEXT
    - Generate comprehensive documentation with GENERATE_DOC
-   - Interactive documentation workflow
-   - Multiple documentation templates
+   - Dynamic template-based documentation menu
+   - Complete multilingual support (Spanish/English)
+   - Direct GitHub repository URL support
+   - Legacy codebase documentation recovery
 
 ## 🚀 Getting Started
 
@@ -218,7 +220,7 @@ The documentation generation process has two main steps:
 
 2. **Generate documentation**:
    ```
-   GENERATE_DOC repo_path=/path/to/repository
+   GENERATE_DOC repo_path=/path/to/repository language=en
    ```
 
 ### Parameters for GENERATE_CONTEXT
@@ -231,10 +233,14 @@ The documentation generation process has two main steps:
 
 ### Parameters for GENERATE_DOC
 
-- `repo_path`: Path to the repository you want to document (optional if context exists)
-- `context_path`: Path to the context directory (optional)
-- `output`: Path where to save the documentation (optional)
+- `repo_path`: Path or GitHub URL to the repository you want to document (required)
+- `language`: Language for documentation output - "en" for English or "es" for Spanish (required)
+- `output`: Path where to save the documentation (optional, default: `docs/generated`)
+- `context_output_file`: Path for the extracted context file (optional)
+- `clone_dir`: Directory for cloning remote repositories (optional)
 - `template`: Documentation template to use (optional)
+- `force_context_regeneration`: Force regenerate context even if exists (optional)
+- `force_clone`: Force re-cloning of remote repository (optional)
 
 ### Examples
 
@@ -242,9 +248,27 @@ The documentation generation process has two main steps:
 # Extract repository context
 GENERATE_CONTEXT repo_path=~/projects/my-api
 
-# Generate documentation
-GENERATE_DOC repo_path=~/projects/my-api template=api-docs output=~/documentation/my-api
+# Generate documentation in English from local repository
+GENERATE_DOC repo_path=~/projects/my-api language=en
+
+# Generate documentation in Spanish from GitHub URL
+GENERATE_DOC repo_path=https://github.com/username/repo language=es
+
+# Generate documentation with custom output path
+GENERATE_DOC repo_path=~/projects/my-api language=en output=~/custom/docs
 ```
+
+### Dynamic Template Menu
+
+When you run `GENERATE_DOC`, the system will:
+
+1. Confirm your preferred language (English or Spanish)
+2. Clone and analyze the repository (if URL provided)
+3. Present a dynamic menu of documentation options based on available templates
+4. Generate documentation according to your selections
+5. Save files to the output directory with proper naming
+
+This process makes it easy to generate exactly the documentation you need from any repository, local or remote.
 
 ## Code Analysis Process
 

--- a/docs/PAELLASEO/.memory.json
+++ b/docs/PAELLASEO/.memory.json
@@ -3,7 +3,7 @@
   "project_type": "Herramienta de análisis SEO",
   "language": "TypeScript",
   "created_at": "2025-03-23T18:55:24Z",
-  "last_updated": "2025-04-05T09:41:49Z",
+  "last_updated": "2025-04-05T10:24:13Z",
   "project_path": "/Users/jlcases/codigo/paellaSEO",
   "methodology": "Test-Driven Development (TDD)",
   "git_workflow": "GitHub Flow",
@@ -477,6 +477,34 @@
   "git_activity": [
     {
       "date": "2025-04-05",
+      "type": "feat",
+      "message": "feat: implement dynamic template-based menu and improved multilingual support (#10)",
+      "files_count": 4,
+      "files": [
+        {
+          "file": "CHANGELOG.md",
+          "dir": ".",
+          "module": "CHANGELOG"
+        },
+        {
+          "file": "README.md",
+          "dir": ".",
+          "module": "README"
+        },
+        {
+          "file": "instructions/GENERATE_DOC.md",
+          "dir": "instructions",
+          "module": "GENERATE_DOC"
+        },
+        {
+          "file": "instructions/README.md",
+          "dir": "instructions",
+          "module": "README"
+        }
+      ]
+    },
+    {
+      "date": "2025-04-05",
       "type": "update",
       "message": "Feat repopack (#9)\n\n* feat: Update rule system with standardized frontmatter, proper English content, and orchestrator file\n\n* docs: Update README\n\n* feat: Add code analysis functionality using repopack-py\n\n* chore: Update .gitignore\n\n* docs: Update README.md\n\n* feat: Add new rules structure and scripts\n\n* fix: Correct version to 0.1.0 reflecting alpha state\n\n* fix: Update version references in TDD setup scripts to 0.1.0\n\n* docs: Update CHANGELOG.md with correct release date\n\n* docs: Highlight repository documentation features in CHANGELOG\n\n* docs: Update date in README badge",
       "files_count": 1,
@@ -502,6 +530,34 @@
       ]
     },
     {
+      "date": "2025-04-05",
+      "type": "feat",
+      "message": "feat: implement dynamic template-based menu and improved multilingual support (#10)",
+      "files_count": 4,
+      "files": [
+        {
+          "file": "CHANGELOG.md",
+          "dir": ".",
+          "module": "CHANGELOG"
+        },
+        {
+          "file": "README.md",
+          "dir": ".",
+          "module": "README"
+        },
+        {
+          "file": "instructions/GENERATE_DOC.md",
+          "dir": "instructions",
+          "module": "GENERATE_DOC"
+        },
+        {
+          "file": "instructions/README.md",
+          "dir": "instructions",
+          "module": "README"
+        }
+      ]
+    },
+    {
       "date": "2025-04-04",
       "type": "docs",
       "message": "docs: Update date in README badge",
@@ -668,26 +724,12 @@
       "date": "2025-04-04",
       "type": "docs",
       "message": "docs: Update date in README badge",
-      "files_count": 0,
-      "files": []
-    },
-    {
-      "date": "2025-03-29",
-      "type": "docs",
-      "message": "docs(PAELLASEO): Crear documento técnico detallado para implementación del modelo Reasonable Surfer",
-      "files_count": 0,
-      "files": []
-    },
-    {
-      "date": "2025-03-29",
-      "type": "docs",
-      "message": "docs(PAELLASEO): Crear documento técnico detallado para implementación del modelo Reasonable Surfer",
       "files_count": 0,
       "files": []
     }
   ],
   "ai_context": {
-    "last_session": "2025-04-05T09:41:49Z",
+    "last_session": "2025-04-05T10:24:13Z",
     "conversation_summaries": [],
     "current_focus": "",
     "coding_preferences": {},

--- a/instructions/GENERATE_DOC.md
+++ b/instructions/GENERATE_DOC.md
@@ -1,0 +1,138 @@
+# GENERATE_DOC Command Reference
+
+## Overview
+
+`GENERATE_DOC` is a powerful command in PAELLADOC that generates comprehensive documentation from code repositories. The command can analyze both local repositories and remote GitHub URLs, extracting key information to create structured documentation based on available templates.
+
+## New in v0.2.0
+
+- **Dynamic Template Menu**: Now displays all available templates organized by category
+- **Complete Multilingual Support**: Full support for both English and Spanish
+- **Direct GitHub URL Support**: Ability to analyze repositories directly from GitHub URLs
+- **Enhanced Output Control**: Better file organization in the output directory
+
+## Syntax
+
+```
+GENERATE_DOC repo_path=<path_or_url> language=<en|es> [options]
+```
+
+## Required Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `repo_path` | Path to local repository or GitHub URL to analyze |
+| `language` | Language for documentation output ("en" for English, "es" for Spanish) |
+
+## Optional Parameters
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `output` | Output directory for generated documentation | `docs/generated` |
+| `context_output_file` | Path for the extracted context file | `code_context/extracted/repo_content.txt` |
+| `clone_dir` | Directory for cloning remote repositories | `temp_cloned_repos` |
+| `template` | Specific documentation template to use | `standard` |
+| `force_context_regeneration` | Force regeneration of context even if it exists | `false` |
+| `force_clone` | Force re-cloning of remote repository | `false` |
+
+## Examples
+
+### Basic Usage with Local Repository
+
+```
+GENERATE_DOC repo_path=/path/to/local/repo language=en
+```
+
+### Documentation from GitHub URL
+
+```
+GENERATE_DOC repo_path=https://github.com/username/repository language=es
+```
+
+### Custom Output Directory
+
+```
+GENERATE_DOC repo_path=/path/to/repo language=en output=/custom/docs/path
+```
+
+### Force Context Regeneration
+
+```
+GENERATE_DOC repo_path=/path/to/repo language=en force_context_regeneration=true
+```
+
+## Process Flow
+
+1. **Language Confirmation**: The system will confirm your preferred language (English or Spanish).
+2. **Repository Analysis**: 
+   - For local repositories, the system analyzes the files directly
+   - For GitHub URLs, the system clones the repository and then analyzes it
+3. **Context Extraction**: Code is converted to a text format for analysis
+4. **Menu Presentation**: A dynamic menu of documentation options is presented based on available templates
+5. **Documentation Generation**: Based on your selection, the system generates documentation
+6. **File Output**: Documentation is saved to the specified output directory
+
+## Dynamic Template Menu
+
+The menu is dynamically generated based on templates available in the system. These templates are organized into categories such as:
+
+- Product Documentation
+- Coding Styles
+- Methodologies
+- Git Workflows
+- Product Management
+
+Each category contains multiple template options that you can select to generate specific documentation.
+
+## Output Files
+
+All generated documentation is saved to the output directory (default: `docs/generated/`) as markdown files. The naming follows a consistent pattern based on the selected template.
+
+## Use Cases
+
+### Legacy Codebase Documentation
+
+Ideal for generating documentation for existing codebases with poor or no documentation. Simply point to your repository and generate comprehensive documentation in minutes.
+
+```
+GENERATE_DOC repo_path=/path/to/legacy/codebase language=en
+```
+
+### Open Source Project Analysis
+
+Quickly understand an open source project's architecture and components by generating documentation directly from its GitHub URL.
+
+```
+GENERATE_DOC repo_path=https://github.com/organization/open-source-project language=en
+```
+
+### Multilingual Documentation
+
+Generate documentation in both English and Spanish to support international teams or projects.
+
+```
+# English documentation
+GENERATE_DOC repo_path=/path/to/repo language=en
+
+# Spanish documentation
+GENERATE_DOC repo_path=/path/to/repo language=es
+```
+
+## Tips
+
+- For best results, ensure your repository follows standard conventions for its language/framework
+- The command works best with repositories that have clear structure and organization
+- For larger repositories, the analysis may take longer but will provide more comprehensive results
+- Use the generated documentation as a starting point and enhance it as needed
+
+## Troubleshooting
+
+- If the command fails to clone a GitHub repository, ensure the URL is correct and the repository is accessible
+- If documentation is incomplete, try using `force_context_regeneration=true` to refresh the analysis
+- For repositories with unusual structures, you may need to specify a custom template
+
+## Related Commands
+
+- `GENERATE_CONTEXT`: Manually extract repository context
+- `PAELLA`: Initialize a new documentation project
+- `CONTINUE`: Continue working on existing documentation 

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -1,0 +1,39 @@
+# PAELLADOC Command Instructions
+
+This directory contains detailed documentation for all PAELLADOC commands.
+
+## Available Command Documentation
+
+- [GENERATE_DOC](./GENERATE_DOC.md) - Generate documentation from code repositories
+- GENERATE_CONTEXT - Extract and process repository content (coming soon)
+- PAELLA - Initialize documentation project (coming soon)
+- CONTINUE - Continue working with existing documentation (coming soon)
+
+## Command Structure
+
+Each command documentation includes:
+
+- Overview and description
+- Required and optional parameters
+- Examples of usage
+- Process flow
+- Tips and troubleshooting
+
+## Latest Updates
+
+### Version 0.2.0 (2025-04-05)
+
+- Added dynamic template menu to GENERATE_DOC
+- Implemented multilingual support (English/Spanish)
+- Added direct GitHub URL support
+- Enhanced output organization
+
+## Using Commands
+
+All PAELLADOC commands follow this basic syntax:
+
+```
+COMMAND param1=value1 param2=value2 [optional_params]
+```
+
+For detailed information about each command, refer to its specific documentation file. 


### PR DESCRIPTION
Creation of an /instructions directory to host command documentation
Complete documentation for the GENERATE_DOC command, including:
Syntax and parameters
New features in v0.2.0 (dynamic menu, multilingual support)
Usage examples and practical use cases
Troubleshooting instructions
README update with information about the new features
CHANGELOG update for version 0.2.0
Date corrections in documentation files
Motivation:
Facilitate the use of the PAELLADOC system by providing clear and detailed documentation on commands, especially the new dynamic menu and multilingual support features.