### PR TITLE
docs(readme): mark v0.x as historical and point to current product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # 🧠 PAELLADOC: The AI-First Development Framework
 
+> **⚠️ Historical — preserved for reference**
+>
+> This repository is **PaellaDoc v0.x** (340+ ⭐, 2024–2025), the original MCP-based framework.
+> The current product is a desktop orchestrator at **[paelladoc.com](https://paelladoc.com)** with native Claude Code, Codex and Gemini integration, Playwright-verified Golden Gate, and a community at **[forum.paelladoc.com](https://forum.paelladoc.com)**.
+>
+> This repo is preserved as historical reference and is no longer actively maintained.
+
+---
+
+
 **[Visit the Official Website](https://paelladoc.com)**
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Adds a clearly visible notice at the top of README announcing that this repo is the original PaellaDoc v0.x framework (340+ ⭐, 2024–2025).
- Points new visitors to the active product at https://paelladoc.com and community at https://forum.paelladoc.com.
- No code changes — README only.

## Why
New visitors landing on this repo (which has organic search authority from the 340 stars) currently get stale code. The notice preserves the historical record while routing them to the live product. It also creates a backlink from a high-authority repo to paelladoc.com, strengthening the brand's E-E-A-T signal across properties.

## Test plan
- [ ] Read the rendered README on the PR's diff view and confirm the notice is the first block after the H1
- [ ] Click both links (paelladoc.com and forum.paelladoc.com) and confirm they resolve